### PR TITLE
Made CannotSeeAgent exception public

### DIFF
--- a/util/src/main/java/uk/ac/imperial/presage2/util/location/CannotSeeAgent.java
+++ b/util/src/main/java/uk/ac/imperial/presage2/util/location/CannotSeeAgent.java
@@ -38,7 +38,7 @@ public class CannotSeeAgent extends RuntimeException {
 	UUID me;
 	UUID them;
 
-	CannotSeeAgent(UUID me, UUID them) {
+	public CannotSeeAgent(UUID me, UUID them) {
 		this.me = me;
 		this.them = them;
 	}


### PR DESCRIPTION
Made CannotSeeAgent exception public to allow new services to throw the exception.
